### PR TITLE
Batched data loader

### DIFF
--- a/src/main/kotlin/com/example/dgs/director/DirectorsDataLoader.kt
+++ b/src/main/kotlin/com/example/dgs/director/DirectorsDataLoader.kt
@@ -1,0 +1,21 @@
+package com.example.dgs.director
+
+import com.netflix.graphql.dgs.DgsDataLoader
+import org.dataloader.BatchLoader
+import org.dataloader.MappedBatchLoader
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.function.Supplier
+
+@DgsDataLoader(name = "directors")
+class DirectorsDataLoader : MappedBatchLoader<Long, Director> {
+    @Autowired
+    private lateinit var directorRepository: DirectorRepository
+
+    override fun load(keys: Set<Long?>): CompletionStage<Map<Long?, Director>> {
+        return CompletableFuture.supplyAsync(Supplier {
+            directorRepository.findAllById(keys).map { it.id to it }.toMap()
+        })
+    }
+}

--- a/src/main/kotlin/com/example/dgs/movie/Movie.kt
+++ b/src/main/kotlin/com/example/dgs/movie/Movie.kt
@@ -17,5 +17,7 @@ data class Movie (
     @Column(name = "release_date", nullable = false)
     val releaseDate: LocalDate,
     @ManyToOne(fetch = FetchType.LAZY)
-    val director: Director? = null
+    val director: Director? = null,
+    @Column(name = "director_id", insertable = false, updatable = false)
+    val directorId: Long
 )

--- a/src/main/kotlin/com/example/dgs/movie/MovieFetcher.kt
+++ b/src/main/kotlin/com/example/dgs/movie/MovieFetcher.kt
@@ -1,6 +1,10 @@
 package com.example.dgs.movie
 
+import com.example.dgs.director.Director
 import com.netflix.graphql.dgs.*
+import graphql.schema.DataFetchingEnvironment
+import org.dataloader.DataLoader
+import java.util.concurrent.CompletableFuture
 
 
 @DgsComponent
@@ -21,5 +25,13 @@ class MovieFetcher(val movieService: MovieService) {
     fun movie(@InputArgument id : String?): Movie? {
         return if (id != null) movieService.getMovieById(id.toLong()) else null
     }
+
+    @DgsData(parentType = "Movie", field = "director")
+    fun movieDirector(dfe: DataFetchingEnvironment): CompletableFuture<List<Director>>? {
+        val dataLoader: DataLoader<Long, List<Director>> = dfe.getDataLoader<Long, List<Director>>("directors")
+        val movie: Movie = dfe.getSource()
+        return dataLoader.load(movie.directorId)
+    }
+
 }
 

--- a/src/main/kotlin/com/example/dgs/movie/MovieMutation.kt
+++ b/src/main/kotlin/com/example/dgs/movie/MovieMutation.kt
@@ -14,16 +14,13 @@ class MovieMutation(
     ) {
     @DgsData(parentType = "Mutation", field = "newMovie")
     fun newMovie(@InputArgument("input") movieInput: MovieInput): Movie {
-
-        val director: Director = directorService.getDirectorById(movieInput.directorId.toLong())
-
         return movieService.createMovie(
             Movie(
                 id = null,
                 name = movieInput.name,
                 description = movieInput.description,
                 releaseDate = LocalDate.parse(movieInput.releaseDate),
-                director = director
+                directorId = movieInput.directorId.toLong()
             )
         )
     }

--- a/src/main/kotlin/com/example/dgs/movie/MovieService.kt
+++ b/src/main/kotlin/com/example/dgs/movie/MovieService.kt
@@ -22,7 +22,7 @@ class MovieService(private val movieRepository: MovieRepository) {
                     name = movie.name,
                     description = movie.description,
                     releaseDate = movie.releaseDate,
-                    director = movie.director
+                    directorId = movie.directorId
                 )
             )
         } else throw ResponseStatusException(HttpStatus.NOT_FOUND, "No matching movie was found")


### PR DESCRIPTION
This is as example of batch loading data to avoid n+1 queries in GraphQL.
This utilizes the data loaders mechanism provided by DGS.

Details: https://netflix.github.io/dgs/data-loaders/